### PR TITLE
fix: profile picture disappears when clicking like or bookmark

### DIFF
--- a/api/routes/home/editbookmark.js
+++ b/api/routes/home/editbookmark.js
@@ -9,7 +9,8 @@ module.exports = async (req, res) => {
         const { postid } = req.body;
         console.log(postid);
         let flag = 0;
-        const post = await Post.findOne({ _id: postid });
+        const post = await Post.findOne({ _id: postid })
+            .populate("owner");
        
         for (let i = 0; i < post.bookmarked.length; i++) {
             if (post.bookmarked[i] === req.user.email) {

--- a/api/routes/home/editlike.js
+++ b/api/routes/home/editlike.js
@@ -8,7 +8,8 @@ module.exports = async (req, res) => {
     try {
         const { postid } = req.body;
         let flag = 0;
-        const post = await Post.findOne({ _id: postid });
+        const post = await Post.findOne({ _id: postid })
+            .populate("owner");
   
         for (let i = 0; i < post.liked.length; i++) {
             if (post.liked[i] === req.user.email) {


### PR DESCRIPTION
This commit solves issue #2.

The cause for the error was that the response of the api endpoints /api/home/editlike and /api/home/editbookmark did not contain the owner object data but only the id of the owner.

Just as in /api/home/getposts the response has to be populated with the owner objects (replace owner ids with owner objects) since the link to the profile picture is only contained in the owner objects.